### PR TITLE
refactor(gaussianpicker): refactor peak finding

### DIFF
--- a/quakemigrate/util.py
+++ b/quakemigrate/util.py
@@ -546,6 +546,19 @@ class ChannelNameException(Exception):
         super().__init__(msg)
 
 
+class NoOnsetPeak(Exception):
+    """
+    Custom exception to handle case when no values in the onset function exceed
+    the threshold used for picking.
+
+    """
+
+    def __init__(self, threshold):
+        self.msg = ("\t\t    No onset signal exceeding threshold "
+                    f"({threshold:5.3f}) - continuing.")
+        super().__init__(self.msg)
+
+
 class BadUpfactorException(Exception):
     """
     Custom exception to handle case when the chosen upfactor does not create a


### PR DESCRIPTION
Refactor the peak finding method in the Gaussian picker to be more
clear. Rather than using an opaque index method, we instead wield some
useful numpy functions, and clearly annotate what is being done. It is
also far easier to add unit tests, as it has been broken down into more
atomic methods.

Credit to Tom for the new _find_peak method, which formed the basis of
this refactoring.

It would be good to add unit tests here, but I would prefer to save the
effort for when the unit testing framework has been created.

This was tested against the Iceland icequake example and gives identical
results.